### PR TITLE
Readme update

### DIFF
--- a/conf/client.properties
+++ b/conf/client.properties
@@ -1,25 +1,25 @@
 # Optional. A hostname of the Server. Use localhost by default if not specified.
-#scalar.ledger.client.server_host=localhost
+scalar.ledger.client.server_host=sandbox.scalar-labs.com
 
-# Optional. A port number of the Server. Use 50051 by default if not specified.
-#scalar.ledger.client.server_port=50051
+# Optional. A port number of the Server.
+scalar.ledger.client.server_port=443
 
 # Required. An ID of a certificate holder.
 # It must be configured for each private key and unique in the system.
-scalar.ledger.client.cert_holder_id=foo
+scalar.ledger.client.cert_holder_id=please_change_me
 
 # Optional. A version of the certificate. Use 1 by default if not specified.
 # Use another bigger integer version number if you lose your private key.
-#scalar.ledger.client.cert_version=1
+scalar.ledger.client.cert_version=1
 
 # Required. A certificate file path to use. 
-scalar.ledger.client.cert_path=./fixture/foo.pem
+scalar.ledger.client.cert_path=/path/to/certificate.pem
 
 # Required. A private key file path to use. 
-scalar.ledger.client.private_key_path=./fixture/foo-key.pem
+scalar.ledger.client.private_key_path=/path/to/private-key.pem
 
 # Optional. A flag to enable TLS communication. False by default.
-#scalar.ledger.client.tls.enabled=false
+scalar.ledger.client.tls.enabled=true
 
 # Optional. A custom CA root certificate for TLS communication.
 # If the issuing certificate authority is known to the client, it can be empty.
@@ -27,5 +27,5 @@ scalar.ledger.client.private_key_path=./fixture/foo-key.pem
 
 # Optional. An authorization credential. (e.g. authorization: Bearer token)
 # If this is given, clients will add "authorization: <credential>" http/2 header.
-#scalar.ledger.client.authorization.credential=
+scalar.ledger.client.authorization.credential=fill_this_in_with_your_token
 

--- a/conf/client.properties
+++ b/conf/client.properties
@@ -1,25 +1,25 @@
 # Optional. A hostname of the Server. Use localhost by default if not specified.
-scalar.ledger.client.server_host=sandbox.scalar-labs.com
+#scalar.ledger.client.server_host=localhost
 
-# Optional. A port number of the Server.
-scalar.ledger.client.server_port=443
+# Optional. A port number of the Server. Use 50051 by default if not specified.
+#scalar.ledger.client.server_port=50051
 
 # Required. An ID of a certificate holder.
 # It must be configured for each private key and unique in the system.
-scalar.ledger.client.cert_holder_id=please_change_me
+scalar.ledger.client.cert_holder_id=foo
 
 # Optional. A version of the certificate. Use 1 by default if not specified.
 # Use another bigger integer version number if you lose your private key.
-scalar.ledger.client.cert_version=1
+#scalar.ledger.client.cert_version=1
 
-# Required. A certificate file path to use. 
-scalar.ledger.client.cert_path=/path/to/certificate.pem
+# Required. A certificate file path to use.
+scalar.ledger.client.cert_path=./fixture/foo.pem
 
-# Required. A private key file path to use. 
-scalar.ledger.client.private_key_path=/path/to/private-key.pem
+# Required. A private key file path to use.
+scalar.ledger.client.private_key_path=./fixture/foo-key.pem
 
 # Optional. A flag to enable TLS communication. False by default.
-scalar.ledger.client.tls.enabled=true
+#scalar.ledger.client.tls.enabled=false
 
 # Optional. A custom CA root certificate for TLS communication.
 # If the issuing certificate authority is known to the client, it can be empty.
@@ -27,5 +27,5 @@ scalar.ledger.client.tls.enabled=true
 
 # Optional. An authorization credential. (e.g. authorization: Bearer token)
 # If this is given, clients will add "authorization: <credential>" http/2 header.
-scalar.ledger.client.authorization.credential=fill_this_in_with_your_token
+#scalar.ledger.client.authorization.credential=
 

--- a/conf/client.properties
+++ b/conf/client.properties
@@ -9,7 +9,7 @@
 scalar.ledger.client.cert_holder_id=foo
 
 # Optional. A version of the certificate. Use 1 by default if not specified.
-# Use another bigger integer version number if you lose your private key.
+# Change to a larger integer version number if you lose your private key.
 #scalar.ledger.client.cert_version=1
 
 # Required. A certificate file path to use.

--- a/docs/dl-getting-started.md
+++ b/docs/dl-getting-started.md
@@ -117,7 +117,7 @@ In Scalar DL 1.0, `asset_id` is not a reserved json key name and you can use any
 
 ## Interact with ClientService 
 
-The tools we have used above are useful for simple testing purposes, but should not be used for production applications. The Client SDK also provides a service layer called `ClientService` which should be used for production applications.
+The tools we have used above are useful for testing purposes, but should not be used for production applications. The Client SDK also provides a service layer called `ClientService` which should be used for production applications.
 The following is a code snippet showing how to use `ClientService` to execute a contract.
 
 ```java

--- a/docs/dl-getting-started.md
+++ b/docs/dl-getting-started.md
@@ -121,15 +121,15 @@ The tools we have used above are useful for simple testing purposes, but should 
 The following is a code snippet showing how to use `ClientService` to execute a contract.
 
 ```java
-  Injector injector =
+Injector injector =
   Guice.createInjector(new ClientModule(new ClientConfig(new File(properties))));
 
-  try (ClientService service = injector.getInstance(ClientService.class)) {
-    JsonObject jsonArgument = Json.createReader(new StringReader(contractArgument)).readObject();
-    ContractExecutionResponse response = service.executeContract(contractId, jsonArgument);
-    System.out.println("status: " + response.getStatus());
-    System.out.println("result: " + response.getResult());
-  }
+try (ClientService service = injector.getInstance(ClientService.class)) {
+  JsonObject jsonArgument = Json.createReader(new StringReader(contractArgument)).readObject();
+  ContractExecutionResponse response = service.executeContract(contractId, jsonArgument);
+  System.out.println("status: " + response.getStatus());
+  System.out.println("result: " + response.getResult());
+}
 ```
 
 It's pretty self-explanatory. It creates a `ClientService` instance using the dependency injection framework called `Guice`,

--- a/docs/dl-getting-started.md
+++ b/docs/dl-getting-started.md
@@ -34,7 +34,7 @@ scalar.ledger.client.cert_path=/path/to/foo.pem
 scalar.ledger.client.private_key_path=/path/to/foo-key.pem
 ```
 
-## Register the certificate
+## Register your certificate
 
 Next, let's register your certificate in the Scalar DL network.
 The registered certificate will allow you to register and execute contracts, and will also be used for tamper detection of the data stored in the network.

--- a/docs/dl-getting-started.md
+++ b/docs/dl-getting-started.md
@@ -132,7 +132,7 @@ try (ClientService service = injector.getInstance(ClientService.class)) {
 }
 ```
 
-It's pretty self-explanatory. It creates a `ClientService` instance using the dependency injection framework called `Guice`,
+The above creates a `ClientService` instance using the dependency injection framework called `Guice`,
 and creates some json argument with `javax.json.JsonObject`.
 Then, you are ready to execute a contract as shown.
 For more information, please take a look at [Javadoc](https://scalar-labs.github.io/scalardl-client-sdk/javadoc/client/).

--- a/docs/dl-getting-started.md
+++ b/docs/dl-getting-started.md
@@ -117,7 +117,7 @@ In Scalar DL 1.0, `asset_id` is not a reserved json key name and you can use any
 
 ## Interact with ClientService 
 
-The tools we have used above are useful for testing purposes, but should not be used for production applications. The Client SDK also provides a service layer called `ClientService` which should be used for production applications.
+The tools we have used above are useful for testing purposes, but should not be used for production applications. The Client SDK provides a service layer called `ClientService` which should be used for production applications.
 The following is a code snippet showing how to use `ClientService` to execute a contract.
 
 ```java

--- a/docs/dl-getting-started.md
+++ b/docs/dl-getting-started.md
@@ -118,7 +118,7 @@ In Scalar DL 1.0, `asset_id` is not a reserved json key name and you can use any
 ## Interact with ClientService 
 
 The tools we have used above are useful for testing purposes, but should not be used for production applications. The Client SDK provides a service layer called `ClientService` which should be used for production applications.
-The following is a code snippet showing how to use `ClientService` to execute a contract.
+The following code snippet shows how to use `ClientService` to execute a contract.
 
 ```java
 Injector injector =

--- a/docs/dl-run-first-contract.md
+++ b/docs/dl-run-first-contract.md
@@ -1,0 +1,69 @@
+# Run your first contract
+
+## Before you begin
+
+You should have already downloaded the `scalardl-client-sdk` directory and registered your certificate. If you haven't ... **add links to other docs here**
+
+## Run the StateUpdater contract
+
+We will run the contract [`scr/main/java/com/org1/contract/StateUpdater.java`](https://github.com/scalar-labs/scalardl-client-sdk/blob/master/src/main/java/com/org1/contract/StateUpdater.java).
+
+In the `scalardl-client-sdk` directory:
+
+1. Compile the contract
+
+    ```
+    $ ./gradlew assemble
+    ```
+
+    This will generate `build/classes/java/main/com/org1/contract/StateUpdater.class`.
+
+2. Register the contract
+
+    ```
+    $ client/bin/register-contract -properties conf/client.properties -contract-id StateUpdater -contract-binary-name com.org1.contract.StateUpdater -contract-class-file build/classes/java/main/com/org1/contract/StateUpdater.class
+    ```
+
+    The `contract-id` is set by the user. Above we have chosen `StateUpdater`, but you can choose anything you like. You can set different contract IDs on the same contract to clarify "who did what" in a tamper-evident way. For example, consider a voting application. In the application, anyone can vote with the same voting logic, and hence can use the same Contract, but A's vote and B's vote need to be properly and securely distinguished; A cannot vote for B, and vice versa. This can be achieved by having different contract IDs on the same contract.
+
+3. Execute the contract
+
+    ```
+    $ client/bin/execute-contract -properties conf/client.properties -contract-id StateUpdater -contract-argument '{"asset_id": "abcdef", "state": 3}'
+    ```
+
+    **Note:** if you are executing the contract in the Sandbox you may want to change the `asset_id`.
+    
+
+## What's next
+
+Anything to add to this section?
+
+
+
+
+## (This should probably be moved or deleted) Interact with ClientService 
+
+The tools we have used above are useful for testing purposes, but should not be used for production applications. The Client SDK also provides a service layer called `ClientService` which should be used for production applications.
+The following is a code snippet showing how to use `ClientService` to execute a contract.
+
+```java
+Injector injector =
+  Guice.createInjector(new ClientModule(new ClientConfig(new File(properties))));
+
+try (ClientService service = injector.getInstance(ClientService.class)) {
+  JsonObject jsonArgument = Json.createReader(new StringReader(contractArgument)).readObject();
+  ContractExecutionResponse response = service.executeContract(contractId, jsonArgument);
+  System.out.println("status: " + response.getStatus());
+  System.out.println("result: " + response.getResult());
+}
+```
+
+It's pretty self-explanatory. It creates a `ClientService` instance using the `Guice` dependency injection framework, and creates a json argument with `javax.json.JsonObject`. Then, it executes the contract and prints out the response.
+
+For more information, please take a look at [Javadoc](https://scalar-labs.github.io/scalardl-client-sdk/javadoc/client/).
+
+## References
+
+* Design Document (coming soon)
+* [Javadoc for client SDK](https://scalar-labs.github.io/scalardl-client-sdk/javadoc/client/)

--- a/docs/dl-sandbox.md
+++ b/docs/dl-sandbox.md
@@ -8,18 +8,11 @@ Sandbox is for playing around with Scalar DL to roughly understand what Scalar D
 This is not for verifying or benchmarking its reliability, scalability and/or performance.
 If you want to interact with Scalar DL more deeply, please [contact us](https://scalar-labs.com/contact_us/).
 
-## Get an auth token and a key pair (a certificate and a private key)
+## Before you begin
 
-You will need to have a [GitHub](https://github.com/) account. If you don't have one, please create an account.
+You will need to have your `client.properties` file, certificate, and private key that you downloaded from [Sandbox Registration](https://scalar-labs.com/sandbox/). If you have not yet registered, please do so now.
 
-We will authorize you through GitHub OAuth to give you an access to the Sandbox environment.
-Please visit [our sandbox site](https://scalar-labs.com/sandbox/), read the [terms of use](https://scalar-labs.com/terms-of-use), and press the button apply for access. We will give
-you an access token and a key pair. The access token is used to authenticate you to the Sandbox
-API gateway, and the key pair is used for communicating with the Scalar DL network.
-
-Please note that we give you a generated key pair for ease of use in the Sandbox, but it is usually required to create your private key in your own environment.
-
-## Before running your first contract 
+## Download the example code
 
 Download the example code from our Github repository (the following command will clone the Scalar DL client SDK).
 
@@ -27,33 +20,27 @@ Download the example code from our Github repository (the following command will
 $ git clone https://github.com/scalar-labs/scalardl-client-sdk.git 
 ```
 
-Scalar DL manages data as a set of assets, where each asset is composed of a history of data identified by a key called `asset_id` and historical version number called `age`.
-`asset_id` is an arbitrary, but unique, string specified by users to manage their assets.
+Then copy your `client.properties` file, certificate, and private key to the `conf` directory in the repository.
 
-**Note.** The Sandbox is a shared environment that anyone can access,
-so please be careful about choosing an appropriate name for your `asset_id`s so that it will not conflict with `asset_id`s chosen by other users. One recommended way to do this is to prepend your username to your asset name as in `<username>_your-asset-name`.
+## Register your certificate
 
-## Configuration
+Next, let's register your certificate in the Scalar DL network. The registered certificate will allow you to register and execute contracts, and will also be used for tamper detection of the data stored in the network.
 
-First, you will need to configure some properties to interact with Sandbox. It is recommended to use the [client.properties](https://github.com/scalar-labs/scalardl-client-sdk/blob/master/conf/client.properties) file contained in the repository. If you want to configure by yourself, please update the following properties in addition to the required properties to interact with Sandbox.
+You may register your certificate with the following command.
 
 ```
-# A host name of Scalar DL Sandbox network
-scalar.ledger.client.server_host=sandbox.scalar-labs.com
-
-# A port number of Scalar DL Sandbox network
-scalar.ledger.client.server_port=443
-
-# A flag to enable TLS communication.
-scalar.ledger.client.tls.enabled=true
-
-# An authorization credential. (e.g. authorization: Bearer token)
-# If this is given, clients will add "authorization: <credential>" http/2 header.
-scalar.ledger.client.authorization.credential=Bearer <your-token>
+$ client/bin/register-cert -properties conf/client.properties
 ```
 
-Now you are ready to follow the "[Getting Started with Scalar DL](dl-getting-started.md)" document to run your first contract. (Again, please note that you need to choose non-conflicting asset ids to properly use the Sandbox.)
 
+## Run your first contract
+
+Now you are ready to follow the "[Run your first contract](dl-run-first-contract.md)" document to run your first contract.
+
+
+##### Note on choosing asset ids in the Sandbox
+
+The Sandbox is a shared environment that anyone can access, so please be careful about choosing an appropriate name for your `asset_id`s so that it will not conflict with `asset_id`s chosen by other users. One recommended way to do this is to prepend your username to your asset name as in `<username>_your-asset-name`.
 
 ## References
 

--- a/docs/dl-sandbox.md
+++ b/docs/dl-sandbox.md
@@ -33,7 +33,7 @@ Scalar DL manages data as a set of assets, where each asset is composed of a his
 **Note.** The Sandbox is a shared environment that anyone can access,
 so please be careful about choosing an appropriate name for your `asset_id`s so that it will not conflict with `asset_id`s chosen by other users. One recommended way to do this is to prepend your username to your asset name as in `<username>_your-asset-name`.
 
-## Run your first contract
+## Configuration
 
 First, you will need to configure some properties to interact with Sandbox. It is recommended to use the [client.properties](https://github.com/scalar-labs/scalardl-client-sdk/blob/master/conf/client.properties) file contained in the repository. If you want to configure by yourself, please update the following properties in addition to the required properties to interact with Sandbox.
 

--- a/docs/dl-sandbox.md
+++ b/docs/dl-sandbox.md
@@ -10,37 +10,32 @@ If you want to interact with Scalar DL more deeply, please [contact us](https://
 
 ## Get an auth token and a key pair (a certificate and a private key)
 
-From here, it assumes that you have a [GitHub](https://github.com/) account.
-If you don't, please create your account.
+You will need to have a [GitHub](https://github.com/) account. If you don't have one, please create an account.
 
 We will authorize you through GitHub OAuth to give you an access to the Sandbox environment.
-Please visit [our sandbox site](https://scalar-labs.com/sandbox/), read the [terms of use](https://scalar-labs.com/terms-of-use), and press the button to do it.
-We will give you an access token and a key pair.
-The access token is used for communicating with Sandbox API gateway to authenticate you.
-The key pair is used for communicating with Scalar DL network.
+Please visit [our sandbox site](https://scalar-labs.com/sandbox/), read the [terms of use](https://scalar-labs.com/terms-of-use), and press the button apply for access. We will give
+you an access token and a key pair. The access token is used to authenticate you to the Sandbox
+API gateway, and the key pair is used for communicating with the Scalar DL network.
 
 Please note that we give you a generated key pair for ease of use in the Sandbox, but it is usually required to create your private key in your own environment.
 
 ## Before running your first contract 
 
-Let's clone Scalar DL client SDK to interact with Scalar DL network.
+Download the example code from our Github repository (the following command will clone the Scalar DL client SDK).
+
 ```
 $ git clone https://github.com/scalar-labs/scalardl-client-sdk.git 
 ```
-You can put your downloaded zip in the directory and unzip it.
 
 Scalar DL manages data as a set of assets, where each asset is composed of a history of data identified by a key called `asset_id` and historical version number called `age`.
-`asset_id` is an arbitrary, but unique, string specified by users to manage their assets. However, the Sandbox is a shared environment that anyone can access,
-so please be careful about choosing an appropriate name so that it will not conflict with `asset_id`s chosen by other users.
-One recommended way to do this is to append your username to your asset name as in `<username>_your-asset-name`.
+`asset_id` is an arbitrary, but unique, string specified by users to manage their assets.
+
+**Note.** The Sandbox is a shared environment that anyone can access,
+so please be careful about choosing an appropriate name for your `asset_id`s so that it will not conflict with `asset_id`s chosen by other users. One recommended way to do this is to prepend your username to your asset name as in `<username>_your-asset-name`.
 
 ## Run your first contract
 
-First, you need to configure some properties to interact with Sandbox.
-It is recommended to use the properties file which can be downloaded from the site.
-If you want to configure by yourself, pleae update the following properties in addition to the required properites to interact with Sandbox.
-Then you are ready to follow [the doc](dl-getting-started.md) to run your first contract.
-(Again, please note that you need to choose non-conflicting asset ids to properly use the Sandbox.)
+First, you will need to configure some properties to interact with Sandbox. It is recommended to use the [client.properties](https://github.com/scalar-labs/scalardl-client-sdk/blob/master/conf/client.properties) file contained in the repository. If you want to configure by yourself, please update the following properties in addition to the required properties to interact with Sandbox.
 
 ```
 # A host name of Scalar DL Sandbox network
@@ -56,6 +51,9 @@ scalar.ledger.client.tls.enabled=true
 # If this is given, clients will add "authorization: <credential>" http/2 header.
 scalar.ledger.client.authorization.credential=Bearer <your-token>
 ```
+
+Now you are ready to follow the "[Getting Started with Scalar DL](dl-getting-started.md)" document to run your first contract. (Again, please note that you need to choose non-conflicting asset ids to properly use the Sandbox.)
+
 
 ## References
 


### PR DESCRIPTION
I update the getting started guide in a few places. I feel that it should probably be rewritten in its entirety. It would be nice if the document simply described in one pass, very simply, how to get up and running and how to execute a contract. For example, the purpose section should be moved to the `README` and `dl-getting-started.md` should be merged into `dl-sandbox.md`. The "What is Scalar DL" probably should also be moved to the `README`.

Anyway, I think that the point is the docs are quite confusing.

I don't mind having a go at fixing it, but I also don't mind not 😄 