### PR TITLE
Fix ValidateLedger contract

### DIFF
--- a/src/main/java/com/scalar/dl/client/contract/ValidateLedger.java
+++ b/src/main/java/com/scalar/dl/client/contract/ValidateLedger.java
@@ -1,9 +1,11 @@
 package com.scalar.dl.client.contract;
 
+import com.scalar.dl.ledger.asset.Asset;
 import com.scalar.dl.ledger.contract.Contract;
 import com.scalar.dl.ledger.database.AssetFilter;
 import com.scalar.dl.ledger.database.Ledger;
 import com.scalar.dl.ledger.exception.ContractContextException;
+import java.util.List;
 import java.util.Optional;
 import javax.json.JsonObject;
 
@@ -19,16 +21,21 @@ public class ValidateLedger extends Contract {
     }
     String assetId = argument.getString(ASSET_ID_KEY);
 
-    // Simply reading the specified assets to return the corresponding AssetProofs
+    Optional<JsonObject> data;
     if (argument.containsKey(AGE_KEY)) {
       int age = argument.getInt(AGE_KEY);
       AssetFilter filter = new AssetFilter(ASSET_ID_KEY).withStartAge(age, true)
           .withEndAge(age, true);
-      ledger.scan(filter);
+      List<Asset> assets = ledger.scan(filter);
+      if (assets.isEmpty()) {
+        data = Optional.empty();
+      } else {
+        data = Optional.of(assets.get(0).data());
+      }
     } else {
-      ledger.get(assetId);
+      data = ledger.get(assetId).map(Asset::data);
     }
 
-    return null;
+    return data.orElse(null);
   }
 }


### PR DESCRIPTION
This PR fixes the bug of linearizable validate-ledger by returning data.
Note that tampering with some other data (e.g., argument) are not detected because it is not visible to the outside of Scalar DL.
Note also that the behavior of linearizable validate-ledger and non-linearizable validate-ledger are different due to their ways of validation.

@scalar-boney 
Can you check again?