### PR TITLE
Upgrade scalardl-java-client-sdk to 3.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.1.0'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.2.0'
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
This PR updates the Gradle build file to upgrade scalardl-java-client-sdk to 3.2.0