### PR TITLE
Upgrade scalardl-java-client-sdk to 3.0.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.0.1'
+    implementation group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '3.0.3'
 }
 
 sourceCompatibility = 1.8


### PR DESCRIPTION
The version 3.0.x is now maintained in the branch 3.0.
This PR upgrade scalardl-java-client-sdk to 3.0.3 to the branch.