### PR TITLE
Fix broken link of Scalar DL Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ dependencies {
 ```
 
 ## Docs
-* [Scalar DL Docs](https://scalardl.readthedocs.io/en/latest/)
+* [Scalar DL Docs](https://scalar-labs.github.io/scalardl/)
 
 ## Contributing 
 This library is mainly maintained by the Scalar Engineering Team, but of course we appreciate any help.


### PR DESCRIPTION
This PR fixes the broken link of Scalar DL Docs.

The following URL in the README returns 404.
https://scalardl.readthedocs.io/en/latest/

It seems that the correct URL is the following.
https://scalar-labs.github.io/scalardl/

Please take a look!